### PR TITLE
Bump uglify-js version to work with more recent node

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "opener": "~1.3.0",
     "shelljs": "~0.2.6",
     "tape": "~4.0.0",
-    "uglify-js": "~2.2.5"
+    "uglify-js": "~2.8.29"
   },
   "keywords": [
     "ace",


### PR DESCRIPTION
Bumps the version of `uglify-js` to the latest v2 release so it works with node v14.5.0